### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,16 +10,16 @@ License
 -------
 APACHE License. (see `LICENSE`_)
 
-.. |build-status| image:: https://travis-ci.org/dls-controls/i10switching.svg?style=flat
-    :target: https://travis-ci.org/dls-controls/i10switching
+.. |build-status| image:: https://travis-ci.org/DiamondLightSource/i10switching.svg?style=flat
+    :target: https://travis-ci.org/DiamondLightSource/i10switching
     :alt: Build Status
 
-.. |coverage| image:: https://coveralls.io/repos/dls-controls/i10switching/badge.svg?branch=master&service=github
-    :target: https://coveralls.io/github/dls-controls/i10switching?branch=master
+.. |coverage| image:: https://coveralls.io/repos/DiamondLightSource/i10switching/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/DiamondLightSource/i10switching?branch=master
     :alt: Test coverage
 
-.. |health| image:: https://landscape.io/github/dls-controls/i10switching/master/landscape.svg?style=flat
-   :target: https://landscape.io/github/dls-controls/i10switching/master
+.. |health| image:: https://landscape.io/github/DiamondLightSource/i10switching/master/landscape.svg?style=flat
+   :target: https://landscape.io/github/DiamondLightSource/i10switching/master
    :alt: Code Health
 
-.. _LICENSE: https://github.com/dls-controls/i10switching/blob/master/LICENSE
+.. _LICENSE: https://github.com/DiamondLightSource/i10switching/blob/master/LICENSE


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/i10switching` using https://gitlab.diamond.ac.uk/github/github-scripts