### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ cache:
     - $HOME/.cache/pip
     - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/lib/python$TRAVIS_PYTHON_VERSION/site-packages
     - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/bin
-    - $HOME/build/dls-controls/PyQt-*
-    - $HOME/build/dls-controls/sip-*
+    - $HOME/build/DiamondLightSource/PyQt-*
+    - $HOME/build/DiamondLightSource/sip-*
 
 before_install:
   - sudo apt-get build-dep python-scipy


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/i10switching` using https://gitlab.diamond.ac.uk/github/github-scripts